### PR TITLE
Add some placeholder commands with typer and setup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ Information about all available executable tasks:
     invoke docker-build
     ```
 
+- Run and serve the backend API
+    ```bash
+    invoke runserver
+    ```
+
 ### Documentation Commands
 -  Build documentation from the docs directory into a static website:
     ```bash 
@@ -112,3 +117,17 @@ Information about all available executable tasks:
     ```bash
     invoke serve-docs
     ```
+
+## CLI's
+
+This project comes with a few different scripts, each with their own options:
+
+### `data.py`
+
+### `evaluate.py`
+
+### `model.py`
+
+### `train.py`
+
+### `visualize.py`

--- a/src/dtu_mlops_project/api.py
+++ b/src/dtu_mlops_project/api.py
@@ -1,0 +1,15 @@
+import fastapi
+from http import HTTPStatus
+
+app = fastapi.FastAPI()
+
+
+@app.get('/')
+def home():
+    """
+    Root end-point (for health-check purposes)
+    """
+    return {
+        'message': HTTPStatus.OK.phrase,
+        'status-code': HTTPStatus.OK
+    }

--- a/src/dtu_mlops_project/data.py
+++ b/src/dtu_mlops_project/data.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from torch.utils.data import Dataset
+
+app = typer.Typer()
 
 
 class MyDataset(Dataset):
@@ -19,11 +22,22 @@ class MyDataset(Dataset):
     def preprocess(self, output_folder: Path) -> None:
         """Preprocess the raw data and save it to the output folder."""
 
-def preprocess(raw_data_path: Path, output_folder: Path) -> None:
+
+@app.command()
+def preprocess(
+    raw_data_path: Annotated[Path, typer.Option("--raw-data")] = "data/raw/",
+    output_folder: Annotated[Path, typer.Option(
+        "--output-folder")] = "data/processed",
+) -> None:
+    """
+
+    :param raw_data_path: Path-like object designating the location of the raw data
+    :param output_folder: Path-lik object designating the location of the output of the preprocessing result.
+    """
     print("Preprocessing data...")
     dataset = MyDataset(raw_data_path)
     dataset.preprocess(output_folder)
 
 
 if __name__ == "__main__":
-    typer.run(preprocess)
+    app()

--- a/src/dtu_mlops_project/evaluate.py
+++ b/src/dtu_mlops_project/evaluate.py
@@ -1,0 +1,14 @@
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def evaluate() -> None:
+    """
+    (Placeholder) Function for evaluating the model.
+    """
+
+
+if __name__ == '__main__':
+    app()

--- a/src/dtu_mlops_project/model.py
+++ b/src/dtu_mlops_project/model.py
@@ -1,0 +1,14 @@
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def model() -> None:
+    """
+    (Placeholder) Function for running the model.
+    """
+
+
+if __name__ == '__main__':
+    app()

--- a/src/dtu_mlops_project/train.py
+++ b/src/dtu_mlops_project/train.py
@@ -1,0 +1,18 @@
+from typing import Annotated
+import typer
+
+
+app = typer.Typer()
+
+
+@app.command()
+def train(output: Annotated[str, typer.Option("--output", "-o")] = "model.ckpt"):
+    """
+    (Placeholder) Trains the model on the data.
+
+    :param output: Destination to write the results to.
+    """
+
+
+if __name__ == '__main__':
+    app()

--- a/tasks.py
+++ b/tasks.py
@@ -7,14 +7,18 @@ PROJECT_NAME = "dtu_mlops_project"
 PYTHON_VERSION = "3.12"
 
 # Setup commands
+
+
 @task
 def create_environment(ctx: Context) -> None:
     """Create a new conda environment for project."""
     ctx.run(
-        f"conda create --name {PROJECT_NAME} python={PYTHON_VERSION} pip --no-default-packages --yes",
+        f"conda create --name {PROJECT_NAME} python={
+            PYTHON_VERSION} pip --no-default-packages --yes",
         echo=True,
         pty=not WINDOWS,
     )
+
 
 @task
 def requirements(ctx: Context) -> None:
@@ -30,15 +34,23 @@ def dev_requirements(ctx: Context) -> None:
     ctx.run('pip install -e .["dev"]', echo=True, pty=not WINDOWS)
 
 # Project commands
+
+
 @task
-def preprocess_data(ctx: Context) -> None:
+def preprocess_data(
+    ctx: Context, raw_data: str = "data/raw",
+    output_folder: str = "data/processed",
+) -> None:
     """Preprocess data."""
-    ctx.run(f"python src/{PROJECT_NAME}/data.py data/raw data/processed", echo=True, pty=not WINDOWS)
+    ctx.run(f"python src/{PROJECT_NAME}/data.py --raw-data {raw_data} --output-folder {output_folder}",
+            echo=True, pty=not WINDOWS)
+
 
 @task
 def train(ctx: Context) -> None:
     """Train model."""
     ctx.run(f"python src/{PROJECT_NAME}/train.py", echo=True, pty=not WINDOWS)
+
 
 @task
 def test(ctx: Context) -> None:
@@ -46,20 +58,39 @@ def test(ctx: Context) -> None:
     ctx.run("coverage run -m pytest tests/", echo=True, pty=not WINDOWS)
     ctx.run("coverage report -m", echo=True, pty=not WINDOWS)
 
+
 @task
 def docker_build(ctx: Context) -> None:
     """Build docker images."""
-    ctx.run("docker build -t train:latest . -f dockerfiles/train.dockerfile", echo=True, pty=not WINDOWS)
-    ctx.run("docker build -t api:latest . -f dockerfiles/api.dockerfile", echo=True, pty=not WINDOWS)
+    ctx.run("docker build -t train:latest . -f dockerfiles/train.dockerfile",
+            echo=True, pty=not WINDOWS)
+    ctx.run("docker build -t api:latest . -f dockerfiles/api.dockerfile",
+            echo=True, pty=not WINDOWS)
+
+
+@task
+def runserver(ctx: Context, port: int = 8000) -> None:
+    """
+    Runs and serves the backend API.
+
+    :param ctx: (Invoke context)
+    :param port: socket port to run the backend on (default: 8000)
+    """
+    ctx.run(f"uvicorn --reload --port {port} dtu_mlops_project.api:app")
+
 
 # Documentation commands
+
+
 @task(dev_requirements)
 def build_docs(ctx: Context) -> None:
     """Build documentation."""
-    ctx.run("mkdocs build --config-file docs/mkdocs.yaml --site-dir build", echo=True, pty=not WINDOWS)
+    ctx.run("mkdocs build --config-file docs/mkdocs.yaml --site-dir build",
+            echo=True, pty=not WINDOWS)
 
 
 @task(dev_requirements)
 def serve_docs(ctx: Context) -> None:
     """Serve documentation."""
-    ctx.run("mkdocs serve --config-file docs/mkdocs.yaml", echo=True, pty=not WINDOWS)
+    ctx.run("mkdocs serve --config-file docs/mkdocs.yaml",
+            echo=True, pty=not WINDOWS)


### PR DESCRIPTION
This PR turns most of the source files in `src/dtu_mlops_project` into scripts using `typer` with placeholder commands (for now) with "reasonable" options. This has incurred a few changes to the `task.py` invoke file to accommodate the new options.

Also, a simple FastAPI backend has been setup with a single end-point for health-checking, so now we have foundation for build a web app (Yay!).